### PR TITLE
feat: Add game progress bar and end game option

### DIFF
--- a/src/components/game/GameHeader.tsx
+++ b/src/components/game/GameHeader.tsx
@@ -1,28 +1,49 @@
+// src/components/game/GameHeader.tsx
+
 "use client";
 
 import React from 'react';
-import { Clock } from 'lucide-react';
+import { Clock, XCircle } from 'lucide-react'; // Added XCircle for the button icon
 import { useGameState } from './GameStateProvider';
+import { Button } from '@/components/ui/button'; // Ensure this path is correct
 
 export const GameHeader: React.FC = () => {
-  const { state } = useGameState();
-  
+  const { state, actions } = useGameState(); // Destructure actions
+
+  const handleEndGame = () => {
+    actions.endSession();
+  };
+
+  // Only show header content if session has started
+  if (!state.sessionStarted) {
+    return null;
+  }
+
   return (
-    <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between mb-2 gap-2 sm:gap-0 w-full max-w-2xl">
-      <h1 className="text-2xl font-bold font-english bg-gradient-to-r from-gradient-yellow via-gradient-orange to-gradient-magenta bg-clip-text text-transparent text-center sm:text-left">
+    <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between mb-4 gap-3 w-full max-w-2xl p-3 bg-slate-50 rounded-lg shadow">
+      <h1 className="text-xl font-bold font-english bg-gradient-to-r from-gradient-yellow via-gradient-orange to-gradient-magenta bg-clip-text text-transparent text-center sm:text-left">
         Jhole Nepali Shabda
       </h1>
-      <div className="flex items-center gap-4 text-muted-foreground justify-center sm:justify-end">
-        <div className="flex items-center gap-2">
+      <div className="flex flex-col sm:flex-row items-center gap-3 sm:gap-4">
+        <div className="flex items-center gap-2 text-xs text-muted-foreground">
           <Clock className="w-4 h-4" />
-          <span className="text-xs font-medium uppercase tracking-wide">Time Duration</span>
-          <span className="font-medium">{state.timerDuration}s</span>
+          <span className="font-medium uppercase tracking-wide">Time:</span>
+          <span className="font-semibold">{state.timerDuration}s</span>
         </div>
-        <div className="flex items-center gap-2">
-          <span className="text-xs font-medium uppercase tracking-wide">Game Mode</span>
-          <span className="font-medium capitalize">{state.difficulty}</span>
+        <div className="flex items-center gap-2 text-xs text-muted-foreground">
+          <span className="font-medium uppercase tracking-wide">Mode:</span>
+          <span className="font-semibold capitalize">{state.difficulty}</span>
         </div>
+        <Button
+          variant="destructive"
+          size="sm"
+          onClick={handleEndGame}
+          className="flex items-center gap-1.5"
+        >
+          <XCircle className="w-4 h-4" />
+          End Game
+        </Button>
       </div>
     </div>
   );
-}; 
+};

--- a/src/components/game/GameStateProvider.tsx
+++ b/src/components/game/GameStateProvider.tsx
@@ -3,6 +3,7 @@
 import React, { createContext, useContext, useReducer, useMemo, useEffect } from 'react';
 import type { GameState, GameActions } from '@/types/game';
 import { gameReducer, initialGameState } from '@/reducers/gameReducer';
+import { initialWordList } from '@/data/words';
 import { useSessionPersistence } from '@/hooks/use-session-persistence';
 import { useSpacedRepetition } from '@/hooks/use-spaced-repetition';
 
@@ -48,6 +49,7 @@ export const GameStateProvider: React.FC<GameStateProviderProps> = ({ children }
   const actions = useMemo<GameActions>(() => ({
     startSession: (duration: number, difficulty) => {
       dispatch({ type: 'START_SESSION', payload: { duration, difficulty } });
+      dispatch({ type: 'SET_TOTAL_WORDS', payload: { count: initialWordList.length } });
     },
     selectNextWord: () => {
       dispatch({ type: 'SELECT_NEXT_WORD' });
@@ -69,6 +71,11 @@ export const GameStateProvider: React.FC<GameStateProviderProps> = ({ children }
     },
     finalizeAssessment: (knewIt: boolean) => {
       dispatch({ type: 'FINALIZE_ASSESSMENT', payload: { knewIt } });
+      if (knewIt) {
+        dispatch({ type: 'INCREMENT_KNOWN_WORDS' });
+      } else {
+        dispatch({ type: 'INCREMENT_UNKNOWN_WORDS' });
+      }
     },
     setClientMounted: (mounted: boolean) => {
       dispatch({ type: 'SET_CLIENT_MOUNTED', payload: { mounted } });
@@ -85,7 +92,16 @@ export const GameStateProvider: React.FC<GameStateProviderProps> = ({ children }
     resetWordState: () => {
       dispatch({ type: 'RESET_WORD_STATE' });
     },
-  }), []);
+    setTotalWords: (count: number) => {
+      dispatch({ type: 'SET_TOTAL_WORDS', payload: { count } });
+    },
+    incrementKnownWords: () => {
+      dispatch({ type: 'INCREMENT_KNOWN_WORDS' });
+    },
+    incrementUnknownWords: () => {
+      dispatch({ type: 'INCREMENT_UNKNOWN_WORDS' });
+    },
+  }), [dispatch]); // Added dispatch to dependency array
 
   useEffect(() => {
     actions.setClientMounted(true);

--- a/src/components/game/ProgressBar.tsx
+++ b/src/components/game/ProgressBar.tsx
@@ -1,0 +1,34 @@
+"use client";
+
+import React from 'react';
+import { useGameState } from './GameStateProvider';
+import { Progress } from '@/components/ui/progress'; // Assuming this is the correct path
+
+export const WordProgressBar: React.FC = () => {
+  const { state } = useGameState();
+  const { knownWords, unknownWords, totalWords, sessionStarted } = state;
+
+  if (!sessionStarted || totalWords === 0) {
+    return null; // Don't show progress bar if session hasn't started or no words
+  }
+
+  const wordsProcessed = knownWords + unknownWords;
+  const progressPercentage = (wordsProcessed / totalWords) * 100;
+
+  return (
+    <div className="w-full p-4 rounded-lg shadow-md">
+      <div className="flex justify-between items-center mb-2 text-sm font-medium">
+        <span className="text-blue-600">
+          Progress: {wordsProcessed} / {totalWords}
+        </span>
+        <div className="space-x-2">
+          <span className="text-green-600">Known: {knownWords}</span>
+          <span className="text-red-600">Unknown: {unknownWords}</span>
+        </div>
+      </div>
+      <Progress value={progressPercentage} className="w-full h-3" />
+      {/* Optional: Display percentage text on progress bar if desired */}
+      {/* <div className="text-xs text-center mt-1">{`${Math.round(progressPercentage)}%`}</div> */}
+    </div>
+  );
+};

--- a/src/components/game/WordDisplaySection.tsx
+++ b/src/components/game/WordDisplaySection.tsx
@@ -4,6 +4,7 @@ import React from 'react';
 import { useGameState } from './GameStateProvider';
 import { /* useEarlyAssessment, */ useFinalAssessment } from '@/hooks/game/useAssessment';
 import { EnhancedWordDisplayCard } from '@/components/enhanced';
+import { WordProgressBar } from '@/components/game';
 
 export const WordDisplaySection: React.FC = () => {
   const { state } = useGameState();
@@ -13,7 +14,8 @@ export const WordDisplaySection: React.FC = () => {
   if (!state.sessionStarted || !state.currentWord) return null;
   
   return (
-    <div className="w-full max-w-2xl">
+    <div className="w-full max-w-2xl space-y-4"> {/* Added space-y-4 for spacing */}
+      <WordProgressBar />
       <EnhancedWordDisplayCard
         word={state.currentWord}
         timeLeft={state.timeLeft}

--- a/src/components/game/index.ts
+++ b/src/components/game/index.ts
@@ -1,0 +1,9 @@
+// src/components/game/index.ts
+export * from './GameHeader';
+export * from './GameSetupModal';
+export * from './GameStateProvider';
+export * from './GameTimerEffect';
+export * from './KeyboardNavigationHandler';
+export * from './SessionEndDialog';
+export * from './WordDisplaySection';
+export * from './ProgressBar'; // Changed from WordProgressBar to ProgressBar to match filename

--- a/src/reducers/gameReducer.ts
+++ b/src/reducers/gameReducer.ts
@@ -17,6 +17,9 @@ export const initialGameState: GameState = {
   isLoadingWord: false,
   isClientMounted: false,
   showEndSessionConfirm: false,
+  totalWords: 0,
+  knownWords: 0,
+  unknownWords: 0,
 };
 
 export const gameReducer = (state: GameState, action: GameAction): GameState => {
@@ -33,6 +36,8 @@ export const gameReducer = (state: GameState, action: GameAction): GameState => 
         assessmentDone: true,
         isTimerRunning: false,
         isLoadingWord: false,
+        knownWords: 0,
+        unknownWords: 0,
       };
       
     case 'SELECT_NEXT_WORD':
@@ -105,6 +110,9 @@ export const gameReducer = (state: GameState, action: GameAction): GameState => 
       return {
         ...initialGameState,
         isClientMounted: state.isClientMounted,
+        totalWords: 0,
+        knownWords: 0,
+        unknownWords: 0,
       };
       
     case 'RESET_WORD_STATE':
@@ -117,6 +125,24 @@ export const gameReducer = (state: GameState, action: GameAction): GameState => 
         timeLeft: state.timerDuration,
       };
       
+    case 'SET_TOTAL_WORDS':
+      return {
+        ...state,
+        totalWords: action.payload.count,
+      };
+
+    case 'INCREMENT_KNOWN_WORDS':
+      return {
+        ...state,
+        knownWords: state.knownWords + 1,
+      };
+
+    case 'INCREMENT_UNKNOWN_WORDS':
+      return {
+        ...state,
+        unknownWords: state.unknownWords + 1,
+      };
+
     default:
       return state;
   }

--- a/src/types/game.ts
+++ b/src/types/game.ts
@@ -17,6 +17,9 @@ export interface GameState {
   isLoadingWord: boolean;
   isClientMounted: boolean;
   showEndSessionConfirm: boolean;
+  totalWords: number;
+  knownWords: number;
+  unknownWords: number;
 }
 
 export type GameAction = 
@@ -32,7 +35,10 @@ export type GameAction =
   | { type: 'SET_LOADING'; payload: { loading: boolean } }
   | { type: 'SHOW_END_SESSION_CONFIRM'; payload: { show: boolean } }
   | { type: 'END_SESSION' }
-  | { type: 'RESET_WORD_STATE' };
+  | { type: 'RESET_WORD_STATE' }
+  | { type: 'SET_TOTAL_WORDS'; payload: { count: number } }
+  | { type: 'INCREMENT_KNOWN_WORDS' }
+  | { type: 'INCREMENT_UNKNOWN_WORDS' };
 
 export interface GameActions {
   startSession: (duration: number, difficulty: WordDifficulty) => void;
@@ -48,4 +54,7 @@ export interface GameActions {
   showEndSessionConfirm: (show: boolean) => void;
   endSession: () => void;
   resetWordState: () => void;
+  setTotalWords: (count: number) => void;
+  incrementKnownWords: () => void;
+  incrementUnknownWords: () => void;
 } 


### PR DESCRIPTION
This commit introduces two new features to the game:

1.  **Game Progress Bar:**
    - Displays the total number of words in the current session.
    - Tracks and shows the count of words marked as "Known" and "Unknown" by you.
    - A visual progress bar indicates the proportion of words processed.
    - State changes are handled in `gameReducer` and `GameStateProvider`.
    - A new `WordProgressBar` component is created and integrated into the `WordDisplaySection`.

2.  **End Game Option:**
    - An "End Game" button is added to the `GameHeader`.
    - Clicking this button ends the current session and returns you to the timer/difficulty selection screen.
    - This utilizes the existing `endSession` action.
    - The `GameHeader` (including the end game button) is now only displayed when a game session is active.

These features enhance your experience by providing clear feedback on your progress and offering control over the game session.