### PR TITLE
refactor: Relocate End Game button beside progress bar with responsiv…

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -28,9 +28,6 @@ export default function NepaliWordMasterPage() {
             {/* Word Display Section */}
             <WordDisplaySection />
             
-            {/* Progress and Controls */}
-            {/* <ProgressSection /> */}
-            
           </div>
           
           {/* Session End Confirmation */}

--- a/src/components/game/EndGameButton.tsx
+++ b/src/components/game/EndGameButton.tsx
@@ -1,0 +1,62 @@
+// src/components/game/EndGameButton.tsx
+"use client";
+
+import React, { useState } from 'react';
+import { Button } from '@/components/ui/button';
+import { XCircle } from 'lucide-react';
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+  AlertDialogTrigger,
+} from "@/components/ui/alert-dialog";
+
+interface EndGameButtonProps {
+  endSession: () => void;
+}
+
+export const EndGameButton: React.FC<EndGameButtonProps> = ({ endSession }) => {
+  const [showConfirmDialog, setShowConfirmDialog] = useState<boolean>(false);
+
+  const handleOpenDialog = () => {
+    setShowConfirmDialog(true);
+  };
+
+  const confirmEndGame = () => {
+    endSession();
+    setShowConfirmDialog(false);
+  };
+
+  return (
+    <AlertDialog open={showConfirmDialog} onOpenChange={setShowConfirmDialog}>
+      <AlertDialogTrigger asChild>
+        <Button
+          variant="destructive"
+          size="sm"
+          onClick={handleOpenDialog} // Changed from handleEndGame to handleOpenDialog for clarity
+          className="flex items-center gap-1.5"
+        >
+          <XCircle className="w-4 h-4" />
+          End Game
+        </Button>
+      </AlertDialogTrigger>
+      <AlertDialogContent>
+        <AlertDialogHeader>
+          <AlertDialogTitle>End Game?</AlertDialogTitle>
+          <AlertDialogDescription>
+            Are you sure you want to end the current game? Your progress will be saved.
+          </AlertDialogDescription>
+        </AlertDialogHeader>
+        <AlertDialogFooter>
+          <AlertDialogCancel onClick={() => setShowConfirmDialog(false)}>Cancel</AlertDialogCancel>
+          <AlertDialogAction onClick={confirmEndGame}>End Game</AlertDialogAction>
+        </AlertDialogFooter>
+      </AlertDialogContent>
+    </AlertDialog>
+  );
+};

--- a/src/components/game/GameHeader.tsx
+++ b/src/components/game/GameHeader.tsx
@@ -2,34 +2,12 @@
 
 "use client";
 
-import React, { useState } from 'react'; // Added useState
-import { Clock, XCircle } from 'lucide-react'; // Added XCircle for the button icon
+import React from 'react';
+import { Clock } from 'lucide-react';
 import { useGameState } from './GameStateProvider';
-import { Button } from '@/components/ui/button'; // Ensure this path is correct
-import {
-  AlertDialog,
-  AlertDialogAction,
-  AlertDialogCancel,
-  AlertDialogContent,
-  AlertDialogDescription,
-  AlertDialogFooter,
-  AlertDialogHeader,
-  AlertDialogTitle,
-  AlertDialogTrigger,
-} from "@/components/ui/alert-dialog"; // Added AlertDialog components
 
 export const GameHeader: React.FC = () => {
-  const { state, actions } = useGameState(); // Destructure actions
-  const [showConfirmDialog, setShowConfirmDialog] = useState<boolean>(false); // Added showConfirmDialog state
-
-  const handleEndGame = () => {
-    setShowConfirmDialog(true); // Modified to show dialog
-  };
-
-  const confirmEndGame = () => {
-    actions.endSession();
-    setShowConfirmDialog(false);
-  };
+  const { state } = useGameState(); // Destructure actions, actions removed
 
   // Only show header content if session has started
   if (!state.sessionStarted) {
@@ -51,31 +29,7 @@ export const GameHeader: React.FC = () => {
           <span className="font-medium uppercase tracking-wide">Mode:</span>
           <span className="font-semibold capitalize">{state.difficulty}</span>
         </div>
-        <AlertDialog open={showConfirmDialog} onOpenChange={setShowConfirmDialog}>
-          <AlertDialogTrigger asChild>
-            <Button
-              variant="destructive"
-              size="sm"
-              onClick={handleEndGame}
-              className="flex items-center gap-1.5"
-            >
-              <XCircle className="w-4 h-4" />
-              End Game
-            </Button>
-          </AlertDialogTrigger>
-          <AlertDialogContent>
-            <AlertDialogHeader>
-              <AlertDialogTitle>End Game?</AlertDialogTitle>
-              <AlertDialogDescription>
-                Are you sure you want to end the current game? Your progress will be saved.
-              </AlertDialogDescription>
-            </AlertDialogHeader>
-            <AlertDialogFooter>
-              <AlertDialogCancel onClick={() => setShowConfirmDialog(false)}>Cancel</AlertDialogCancel>
-              <AlertDialogAction onClick={confirmEndGame}>End Game</AlertDialogAction>
-            </AlertDialogFooter>
-          </AlertDialogContent>
-        </AlertDialog>
+        {/* End Game Button and AlertDialog logic has been moved to EndGameButton.tsx */}
       </div>
     </div>
   );

--- a/src/components/game/ProgressAndControlsSection.tsx
+++ b/src/components/game/ProgressAndControlsSection.tsx
@@ -1,0 +1,27 @@
+// src/components/game/ProgressAndControlsSection.tsx
+"use client";
+
+import React from 'react';
+import { WordProgressBar } from './ProgressBar'; // Assuming ProgressBar.tsx exists and exports WordProgressBar
+import { EndGameButton } from './EndGameButton';
+import { useGameState } from './GameStateProvider';
+
+export const ProgressAndControlsSection: React.FC = () => {
+  const { actions, state } = useGameState();
+
+  // Only render if the session has started
+  if (!state.sessionStarted) {
+    return null;
+  }
+
+  return (
+    <div className="w-full flex flex-col sm:flex-row sm:items-center sm:justify-between gap-4 p-4 rounded-lg shadow-md">
+      <div className="flex-grow"> {/* This div will ensure progress bar takes available space */}
+        <WordProgressBar />
+      </div>
+      <div className="flex-shrink-0"> {/* This div will prevent button from shrinking/wrapping unnecessarily */}
+        <EndGameButton endSession={actions.endSession} />
+      </div>
+    </div>
+  );
+};

--- a/src/components/game/WordDisplaySection.tsx
+++ b/src/components/game/WordDisplaySection.tsx
@@ -4,7 +4,7 @@ import React from 'react';
 import { useGameState } from './GameStateProvider';
 import { /* useEarlyAssessment, */ useFinalAssessment } from '@/hooks/game/useAssessment';
 import { EnhancedWordDisplayCard } from '@/components/enhanced';
-import { WordProgressBar } from '@/components/game';
+import { ProgressAndControlsSection } from '@/components/game'; // Changed import
 
 export const WordDisplaySection: React.FC = () => {
   const { state } = useGameState();
@@ -25,7 +25,7 @@ export const WordDisplaySection: React.FC = () => {
         onFinalAssessment={finalAssessment}
         showFinalAssessment={state.meaningsVisible && !state.assessmentDone}
       />
-      <WordProgressBar />
+      <ProgressAndControlsSection />
     </div>
   );
 }; 

--- a/src/components/game/index.ts
+++ b/src/components/game/index.ts
@@ -7,3 +7,4 @@ export * from './KeyboardNavigationHandler';
 export * from './SessionEndDialog';
 export * from './WordDisplaySection';
 export * from './ProgressBar'; // Changed from WordProgressBar to ProgressBar to match filename
+export * from './ProgressAndControlsSection';


### PR DESCRIPTION
…e layout

I refactored the "End Game" button and its confirmation dialog into a reusable `EndGameButton.tsx` component.

I introduced a new `ProgressAndControlsSection.tsx` component to manage the layout of the `WordProgressBar` and the `EndGameButton`. This new section arranges these two components:
- Inline on desktop screens (progress bar left, button right).
- Stacked on mobile screens (progress bar top, button bottom).

I updated `WordDisplaySection.tsx` to use this new `ProgressAndControlsSection`. `GameHeader.tsx` no longer contains the "End Game" button. I also performed minor cleanup in `app/page.tsx`.

The functionality of the "End Game" confirmation dialog and the progress bar remains unchanged.