### PR TITLE
Improve assessment button reliability

### DIFF
--- a/src/guess-the-word/components/KeyboardNavigationHandler.tsx
+++ b/src/guess-the-word/components/KeyboardNavigationHandler.tsx
@@ -6,7 +6,7 @@ import { useFinalAssessment, useWordSelection } from '../hooks'; // Corrected pa
 
 export const KeyboardNavigationHandler: React.FC = () => {
   const { state } = useGameState();
-  const finalAssessment = useFinalAssessment();
+  const { finalAssessment } = useFinalAssessment();
   const selectNextWord = useWordSelection();
 
   useEffect(() => {

--- a/src/guess-the-word/components/WordCard.tsx
+++ b/src/guess-the-word/components/WordCard.tsx
@@ -72,7 +72,7 @@ const WordMeaningContent: React.FC<{ wordData: { roman: string; meaning_nepali: 
 
 export const WordCard: React.FC = () => {
   const { state } = useGameState();
-  const finalAssessment = useFinalAssessment();
+  const { finalAssessment, isProcessing } = useFinalAssessment();
   const [cardFlipped, setCardFlipped] = useState(false);
 
   useEffect(() => {
@@ -129,7 +129,7 @@ export const WordCard: React.FC = () => {
       </div>
       {/* Assessment Controls - Rendered outside and below the flipping card */}
       {meaningsVisible && !assessmentDone && (
-        <AssessmentControls onAssess={finalAssessment} disabled={assessmentDone} />
+        <AssessmentControls onAssess={finalAssessment} disabled={assessmentDone || isProcessing} />
       )}
     </div>
   );


### PR DESCRIPTION
## Summary
- add processing flag to `useFinalAssessment` to block double submits
- disable assessment controls while processing
- update keyboard handler to use new hook API

## Testing
- `npm test` *(fails: Missing script)*
- `npm run lint` *(fails: next not found)*
- `npm run typecheck` *(fails: cannot find module 'next')*

------
https://chatgpt.com/codex/tasks/task_e_6842ead49b5c8326962a945dc9d12fba