### PR TITLE
Persist spaced repetition stats

### DIFF
--- a/src/guess-the-word/components/EndSessionDialog.tsx
+++ b/src/guess-the-word/components/EndSessionDialog.tsx
@@ -20,8 +20,7 @@ export const EndSessionDialog: React.FC = () => { // Renamed component
     actions.showEndSessionConfirm(false);
     
     resetSessionData({});
-    srSystem.resetWordStats();
-    
+
     actions.endSession();
   };
 

--- a/src/guess-the-word/components/GameSetupDialog.tsx
+++ b/src/guess-the-word/components/GameSetupDialog.tsx
@@ -20,8 +20,7 @@ export const GameSetupDialog: React.FC = () => { // Renamed component
   const handleConfirmSettingsAndStart = useCallback(() => {
     gameSettingsRef.current = { timerDuration: selectedTimer, difficulty: selectedDifficulty };
     actions.startSession(selectedTimer, selectedDifficulty);
-    resetSessionData({}); 
-    srSystem.resetWordStats();
+    resetSessionData({});
   }, [selectedTimer, selectedDifficulty, actions, resetSessionData, srSystem]);
 
   useEffect(() => {

--- a/src/guess-the-word/context.tsx
+++ b/src/guess-the-word/context.tsx
@@ -4,7 +4,8 @@ import React, { createContext, useContext, useReducer, useMemo, useEffect } from
 import type { GameState, GameActions } from './types';
 import { gameReducer, initialGameState } from './reducer'; // Updated path
 import { initialWordList } from './data';
-import { useSessionPersistence, useSpacedRepetition, type SpacedRepetitionSystem, type SessionData } from './hooks'; // Import SpacedRepetitionSystem and SessionData
+import { useSessionPersistence, useSpacedRepetition, type SpacedRepetitionSystem } from './hooks';
+import type { SessionData } from './types';
 
 interface GameStateContextValue {
   state: GameState;

--- a/src/guess-the-word/types.ts
+++ b/src/guess-the-word/types.ts
@@ -10,6 +10,13 @@ export interface Word {
   difficulty: WordDifficulty;
 }
 
+export interface SessionData {
+  shownWordIds: number[];
+  totalKnown: number;
+  totalUnknown: number;
+  lastSessionDate: string;
+}
+
 // ====== From src/types/game.ts ======
 // import type { Word, WordDifficulty } from './index'; // No longer needed as types are in the same file
 


### PR DESCRIPTION
### **User description**
## Summary
- centralize `SessionData` type
- store spaced repetition data to localStorage only on updates
- keep word stats between sessions
- streamline game timer hook and remove unused actions

## Testing
- `npm run lint` *(fails: `next` not found)*
- `npm run typecheck` *(fails: missing modules)*

------
https://chatgpt.com/codex/tasks/task_e_68430439ebb0832699e1b527a747c586


___

### **PR Type**
Enhancement


___

### **Description**
- Centralized `SessionData` type in `types.ts` for consistency

- Improved persistence of spaced repetition stats to localStorage
  - Now only updates localStorage on relevant changes
  - Ensures word stats persist between sessions

- Streamlined session and spaced repetition reset logic

- Removed unused or redundant actions and code for clarity


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>hooks.ts</strong><dd><code>Centralize SessionData and optimize persistence logic</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/guess-the-word/hooks.ts

<li>Removed duplicate <code>SessionData</code> interface, now imported from <code>types.ts</code><br> <li> Updated session and spaced repetition persistence to write to <br>localStorage only on updates<br> <li> Moved localStorage updates inside update/reset functions for <br>efficiency<br> <li> Removed unused <code>clearSessionData</code> and streamlined timer hook


</details>


  </td>
  <td><a href="https://github.com/koiralaprijun00/guess-the-word/pull/5/files#diff-c3d8a8b46f63020c4b261af9890de070f6849966d5cbb33573c4d37def5a106d">+45/-56</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>types.ts</strong><dd><code>Centralize SessionData type definition</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/guess-the-word/types.ts

- Added `SessionData` interface to centralize type definition


</details>


  </td>
  <td><a href="https://github.com/koiralaprijun00/guess-the-word/pull/5/files#diff-ae5f104dfe7dcebd706f504b1ab009153c31c06b6645fb43a28e8c14f875385a">+7/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>EndSessionDialog.tsx</strong><dd><code>Simplify end session logic</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/guess-the-word/components/EndSessionDialog.tsx

<li>Removed redundant call to <code>srSystem.resetWordStats()</code> on session end


</details>


  </td>
  <td><a href="https://github.com/koiralaprijun00/guess-the-word/pull/5/files#diff-d09924481d43f89184070a05822f5cf119d0a6fa5586ab11a7a142ef7222cc6f">+1/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>GameSetupDialog.tsx</strong><dd><code>Streamline game setup session reset</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/guess-the-word/components/GameSetupDialog.tsx

- Removed redundant call to `srSystem.resetWordStats()` on game setup


</details>


  </td>
  <td><a href="https://github.com/koiralaprijun00/guess-the-word/pull/5/files#diff-f30c0c9222e100ba08cc60a51f2ab167521eed1ebae6dbb7ac13655f3828ca11">+1/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>context.tsx</strong><dd><code>Use centralized SessionData type in context</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/guess-the-word/context.tsx

- Updated import to use centralized `SessionData` from `types.ts`


</details>


  </td>
  <td><a href="https://github.com/koiralaprijun00/guess-the-word/pull/5/files#diff-8c1d4aa1ceaeec078360cbe7eda57e42cc0ff08d208a065711c5174445429057">+2/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>